### PR TITLE
Check terms before iterating through them

### DIFF
--- a/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
+++ b/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
@@ -474,9 +474,11 @@ if(!class_exists('DPSFolioAuthor\CMS')) {
 			$taxonomy_names = get_object_taxonomies( $post->post_type );
 			foreach($taxonomy_names as $taxonomy){
 				$terms = get_the_terms( $id, $taxonomy );
-				foreach($terms as $term){
-					array_push($internalKeywords, $term->name);
-				}
+                if($terms) {
+    				foreach($terms as $term){
+    					array_push($internalKeywords, $term->name);
+    				}
+                }
 			}
 			
 			$entity->title = $post->post_title;

--- a/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
+++ b/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
@@ -474,11 +474,11 @@ if(!class_exists('DPSFolioAuthor\CMS')) {
 			$taxonomy_names = get_object_taxonomies( $post->post_type );
 			foreach($taxonomy_names as $taxonomy){
 				$terms = get_the_terms( $id, $taxonomy );
-                if($terms) {
-    				foreach($terms as $term){
-    					array_push($internalKeywords, $term->name);
-    				}
-                }
+				if($terms) {
+					foreach($terms as $term){
+						array_push($internalKeywords, $term->name);
+					}
+				}
 			}
 			
 			$entity->title = $post->post_title;


### PR DESCRIPTION
Using the function `get_the_terms()` can return false (see https://codex.wordpress.org/Function_Reference/get_the_terms) so we should check if we get any items before iterating through them. Fixes the Error when importing Articles from Wordpress.
