### PR TITLE
Use a empty string for the add_query_arg() function.

### DIFF
--- a/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
+++ b/classes/cms-modules/wordpress/dpsfa-cms-wordpress.php
@@ -588,7 +588,7 @@ if(!class_exists('DPSFolioAuthor\CMS')) {
 					}
 					
 					// build the redirect url
-					$sendback = add_query_arg( array('imported' => $imported, 'ids' => join(',', $post_ids) ), $sendback );
+					$sendback = add_query_arg( array('imported' => $imported, 'ids' => join(',', $post_ids) ), "" );
 				
 					break;
 				default: return;


### PR DESCRIPTION
 Using a undefined variable / null throws errors or gives a redirect loop.
