### PR TITLE
Update dpsfa-adobe.php

### DIFF
--- a/classes/dpsfa-adobe.php
+++ b/classes/dpsfa-adobe.php
@@ -966,6 +966,7 @@ if(!class_exists('DPSFolioAuthor\Adobe')) {
 									
 			$entityAttributes["entityName"] = $entity->entityName;
 			$entityAttributes["entityType"] = $entity->entityType;
+			unset($entityAttributes["_links"]['altAssetUrl']);
 			
 			return array_merge($entityAttributes,$overrides);
 		}


### PR DESCRIPTION
Force remove the ['_links']['altAssetUrl'] from entity metadata to avoid current errors on thumbnail upload or metadata update.